### PR TITLE
Added integration support to the event objects

### DIFF
--- a/Entity/Integration.php
+++ b/Entity/Integration.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2015 Lp digital system
+ *
+ * This file is part of Github Parser library.
+ *
+ * Github Parser is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Github Parser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Github Parser. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Lpdigital\Github\Entity;
+
+class Integration
+{
+    /**
+     * @var int
+     */
+    private $installationId;
+
+    /**
+     * @param array $data
+     *
+     * @return self
+     */
+    public static function createFromData(array $data)
+    {
+        return new static($data);
+    }
+
+    public function __construct(array $data)
+    {
+        $this->installationId = $data['id'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getInstallationId()
+    {
+        return $this->installationId;
+    }
+
+    /**
+     * @param int $installationId
+     *
+     * @return self
+     */
+    public function setInstallationId($installationId)
+    {
+        $this->installationId = $installationId;
+
+        return $this;
+    }
+}

--- a/EventType/AbstractEventType.php
+++ b/EventType/AbstractEventType.php
@@ -21,6 +21,7 @@
 
 namespace Lpdigital\Github\EventType;
 
+use Lpdigital\Github\Entity\Integration;
 use Lpdigital\Github\Entity\Repository;
 use Lpdigital\Github\Exception\RepositoryNotFoundException;
 
@@ -28,6 +29,11 @@ abstract class AbstractEventType implements GithubEventInterface
 {
     private $data;
     public $repository;
+
+    /**
+     * @var Integration|null
+     */
+    public $integration;
 
     public function getPayload()
     {
@@ -69,5 +75,7 @@ abstract class AbstractEventType implements GithubEventInterface
         } catch (\Exception $e) {
             throw new RepositoryNotFoundException($e->getMessage());
         }
+
+        $this->integration = isset($data['installation']) ? Integration::createFromData($data['installation']) : null;
     }
 }

--- a/Tests/Parser/WebhookResolverTest.php
+++ b/Tests/Parser/WebhookResolverTest.php
@@ -196,6 +196,16 @@ class WebhookResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf("Lpdigital\Github\Entity\Commit", $commit);
     }
 
+    public function testResolvePullRequestHasIntegration()
+    {
+        ini_restore('user_agent');
+        ini_set('user_agent', 'GitHub event parser user agent');
+        $jsonReceived = json_decode(file_get_contents($this->jsonDataFolder.'pull_request_event.json'), true);
+        $event = $this->resolver->resolve($jsonReceived);
+
+        $this->assertInstanceOf("Lpdigital\Github\Entity\Integration", $event->integration);
+    }
+
     public function testResolvePullRequestEventCommitThrowsException()
     {
         $this->setExpectedException('Lpdigital\Github\Exception\UserAgentNotFoundException');

--- a/Tests/json-data/pull_request_event.json
+++ b/Tests/json-data/pull_request_event.json
@@ -408,5 +408,8 @@
     "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
     "type": "User",
     "site_admin": false
+  },
+  "installation": {
+    "id": 1234
   }
 }


### PR DESCRIPTION
This pr adds an integration object to the github event if an installation id was send with the request. 

> In addition to the fields documented for each event, webhook payloads include the user who performed the event (sender) as well as the organization (organization) and/or repository (repository) which the event occurred on, and for an Integration's webhook may include the installation (installation) which an event relates to.

See: https://developer.github.com/webhooks/#payloads 

Closes #39 