### PR TITLE
Travis config tweaks to speed up builds (cache composer files)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ sudo: false
 php:
     - 5.6
     - 7.0
+    - 7.1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
 
 before_install:
   - composer self-update
 
 before_script:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction
 
 script:
   - phpunit --coverage-clover=coverage.clover


### PR DESCRIPTION
I did some tweaks to the travis config file:

- Cache the vendor folder and composer cache directory
- Use the dist packages instead of source files

This should speedup the builds. I've also added php 7.1 to the build matrix as it is out for some time now and would be good to test against this version also.

The real speedup will not be visible in this build but ofcourse with next builds using this saved cache it should make a difference!